### PR TITLE
Update CI for release v23.06.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-11, windows-2019]
-        sofa_branch: [master]
+        sofa_branch: [v23.06]
         python_version: ['3.8']
 
     steps:


### PR DESCRIPTION
Create a v23.06 release for the SoftRobots Inverse plugin. This is required to have associated assets to make a conda package for the plugin.