### PR TITLE
Remove python2 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,9 +174,6 @@ if(SOFA_HAVE_NEWMAT)
     target_link_libraries(${PROJECT_NAME} SofaDenseSolver)
 endif()
 
-# Config files and install rules for pythons scripts
-sofa_install_pythonscripts(PLUGIN_NAME ${PROJECT_NAME} PYTHONSCRIPTS_SOURCE_DIR "python")
-
 ## Install rules for the library and headers; CMake package configurations files
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/python/__softrobotsinverse__/__init__.py
+++ b/python/__softrobotsinverse__/__init__.py
@@ -1,1 +1,0 @@
-isAvailable=True


### PR DESCRIPTION
This PR removes plugin python2 support. This will avoid polluting `etc/sofa/python.d/` path with some invalid python paths that would be then considered in the setup python environment phase of SofaPython3 plugin.