### PR TITLE
[constraint] SlidingActuator: new feature

### DIFF
--- a/src/SoftRobots.Inverse/component/constraint/SlidingActuator.h
+++ b/src/SoftRobots.Inverse/component/constraint/SlidingActuator.h
@@ -138,6 +138,7 @@ protected:
     sofa::Data<double>                d_force;
     sofa::Data<double>                d_initDisplacement;
     sofa::Data<double>                d_displacement;
+    sofa::Data<bool>                  d_accumulateDisp;
 
     sofa::Data<bool>                  d_showDirection;
     sofa::Data<double>                d_showVisuScale;


### PR DESCRIPTION
If the constraint is attached to a fixed object, the displacement becomes relative. In that case, we lose information about the total displacement applied.

This PR allows to accumulate the displacement, avoiding to lose this information.
