### PR TITLE
[binding] QPInverseProblemSolver: adds python binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,11 @@ if(SOFA_HAVE_NEWMAT)
     target_link_libraries(${PROJECT_NAME} SofaDenseSolver)
 endif()
 
+find_package(SofaPython3 QUIET)
+if(SofaPython3_FOUND)
+    add_subdirectory(${SRC_DIR}/binding)
+endif()
+
 ## Install rules for the library and headers; CMake package configurations files
 sofa_create_package_with_targets(
     PACKAGE_NAME ${PROJECT_NAME}

--- a/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.cpp
+++ b/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.cpp
@@ -73,7 +73,7 @@ bool QPInverseProblemSolver_Trampoline::solveSystem(const sofa::core::Constraint
     SOFA_UNUSED(res1);
     SOFA_UNUSED(res2);
 
-    bool result = solveSystem();
+    const bool result = solveSystem();
     storeResults();
 
     return result;
@@ -87,12 +87,12 @@ void QPInverseProblemSolver_Trampoline::storeResults()
 
     solver::module::QPInverseProblem::QPConstraintLists* qpCLists = m_currentCP->getQPConstraintLists();
 
-    std::size_t nbActuatorRows = qpCLists->actuatorRowIds.size();
-    std::size_t nbEffectorRows = qpCLists->effectorRowIds.size();
-    std::size_t nbSensorRows   = qpCLists->sensorRowIds.size();
-    std::size_t nbContactRows  = qpCLists->contactRowIds.size();
-    std::size_t nbEqualityRows = qpCLists->equalityRowIds.size();
-    std::size_t nbRows = nbEffectorRows + nbActuatorRows + nbContactRows + nbSensorRows + nbEqualityRows;
+    const std::size_t nbActuatorRows = qpCLists->actuatorRowIds.size();
+    const std::size_t nbEffectorRows = qpCLists->effectorRowIds.size();
+    const std::size_t nbSensorRows   = qpCLists->sensorRowIds.size();
+    const std::size_t nbContactRows  = qpCLists->contactRowIds.size();
+    const std::size_t nbEqualityRows = qpCLists->equalityRowIds.size();
+    const std::size_t nbRows = nbEffectorRows + nbActuatorRows + nbContactRows + nbSensorRows + nbEqualityRows;
 
     solver::module::QPInverseProblemImpl::QPSystem* qpSystem = m_currentCP->getQPSystem();
     qpSystem->delta.resize(nbRows);

--- a/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.cpp
+++ b/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.cpp
@@ -1,0 +1,113 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+*                       Plugin SoftRobots.Inverse                             *
+*                                                                             *
+* This plugin is distributed under the GNU AGPL v3 (Affero General            *
+* Public License) license.                                                    *
+*                                                                             *
+* Authors: Christian Duriez, Eulalie Coevoet, Yinoussa Adagolodjo             *
+*                                                                             *
+* (c) 2023 INRIA                                                              *
+*                                                                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+******************************************************************************/
+
+#include <pybind11/pybind11.h>
+#include <pybind11/eigen.h>
+
+#include <SofaPython3/PythonFactory.h>
+#include <SofaPython3/PythonEnvironment.h>
+#include <SofaPython3/Sofa/Core/Binding_Base.h>
+
+#include <SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.h>
+#include <SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver_doc.h>
+
+SOFAPYTHON3_BIND_ATTRIBUTE_ERROR()
+
+/// Makes an alias for the pybind11 namespace to increase readability.
+namespace py { using namespace pybind11; }
+
+namespace softrobotsinverse::python3
+{
+using sofa::core::objectmodel::Event;
+using sofa::core::objectmodel::BaseObject;
+using softrobotsinverse::solver::QPInverseProblemSolver;
+using EigenDenseMatrix = Eigen::Matrix<SReal, Eigen::Dynamic, Eigen::Dynamic>;
+using EigenMatrixMap = Eigen::Map<EigenDenseMatrix>;
+
+std::string QPInverseProblemSolver_Trampoline::getClassName() const
+{
+    sofapython3::PythonEnvironment::gil acquire {"getClassName"};
+    // Get the actual class name from python.
+    return py::str(py::cast(this).get_type().attr("__name__"));
+}
+
+bool QPInverseProblemSolver_Trampoline::solveSystem()
+{
+    PYBIND11_OVERLOAD_PURE(bool,
+                          QPInverseProblemSolver_Trampoline,
+                          solveSystem,
+                          );
+}
+
+bool QPInverseProblemSolver_Trampoline::solveSystem(const sofa::core::ConstraintParams* cParams,
+                                                    sofa::core::MultiVecId res1,
+                                                    sofa::core::MultiVecId res2)
+{
+    SOFA_UNUSED(cParams);
+    SOFA_UNUSED(res1);
+    SOFA_UNUSED(res2);
+
+    return solveSystem();
+}
+
+void moduleAddQPInverseProblemSolver(py::module &m)
+{
+    py::class_<softrobotsinverse::solver::QPInverseProblemSolver,
+               QPInverseProblemSolver_Trampoline,
+               BaseObject,
+               sofapython3::py_shared_ptr<softrobotsinverse::solver::QPInverseProblemSolver>> s(m, "QPInverseProblemSolver",
+                                         py::dynamic_attr(),
+                                         softrobotsinverse::python3::doc::QPInverseProblemSolver);
+
+    s.def(py::init<>());
+    s.def("solveSystem", &softrobotsinverse::solver::QPInverseProblemSolver::solveSystem);
+
+    s.def("W", [](QPInverseProblemSolver& self) -> EigenMatrixMap
+        {
+            assert(self.getConstraintProblem());
+            auto& W_matrix = self.getConstraintProblem()->W;
+            return { W_matrix.ptr(), W_matrix.rows(), W_matrix.cols()};
+        });
+
+    s.def("lambda_force", [](QPInverseProblemSolver& self) -> Eigen::Map<Eigen::Matrix<SReal, Eigen::Dynamic, 1> >
+        {
+            assert(self.getConstraintProblem());
+            auto& lambda = self.getConstraintProblem()->f;
+            return { lambda.ptr(), lambda.size()};
+        });
+
+    s.def("dfree", [](QPInverseProblemSolver& self) -> Eigen::Map<Eigen::Matrix<SReal, Eigen::Dynamic, 1> >
+        {
+            assert(self.getConstraintProblem());
+            auto& dfree = self.getConstraintProblem()->dFree;
+            return { dfree.ptr(), dfree.size()};
+        });
+}
+
+}

--- a/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.cpp
+++ b/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.cpp
@@ -109,35 +109,14 @@ void QPInverseProblemSolver_Trampoline::storeResults()
 void moduleAddQPInverseProblemSolver(py::module &m)
 {
     py::class_<softrobotsinverse::solver::QPInverseProblemSolver,
+               sofa::component::constraint::lagrangian::solver::ConstraintSolverImpl,
                QPInverseProblemSolver_Trampoline,
-               BaseObject,
                sofapython3::py_shared_ptr<softrobotsinverse::solver::QPInverseProblemSolver>> s(m, "QPInverseProblemSolver",
                                          py::dynamic_attr(),
                                          softrobotsinverse::python3::doc::QPInverseProblemSolver);
 
     s.def(py::init<>());
     s.def("solveSystem", &softrobotsinverse::solver::QPInverseProblemSolver::solveSystem);
-
-    s.def("W", [](QPInverseProblemSolver& self) -> EigenMatrixMap
-        {
-            assert(self.getConstraintProblem());
-            auto& W_matrix = self.getConstraintProblem()->W;
-            return { W_matrix.ptr(), W_matrix.rows(), W_matrix.cols()};
-        });
-
-    s.def("lambda_force", [](QPInverseProblemSolver& self) -> Eigen::Map<Eigen::Matrix<SReal, Eigen::Dynamic, 1> >
-        {
-            assert(self.getConstraintProblem());
-            auto& lambda = self.getConstraintProblem()->f;
-            return { lambda.ptr(), lambda.size()};
-        });
-
-    s.def("dfree", [](QPInverseProblemSolver& self) -> Eigen::Map<Eigen::Matrix<SReal, Eigen::Dynamic, 1> >
-        {
-            assert(self.getConstraintProblem());
-            auto& dfree = self.getConstraintProblem()->dFree;
-            return { dfree.ptr(), dfree.size()};
-        });
 }
 
 }

--- a/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.cpp
+++ b/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.cpp
@@ -81,25 +81,25 @@ bool QPInverseProblemSolver_Trampoline::solveSystem(const sofa::core::Constraint
 
 void QPInverseProblemSolver_Trampoline::storeResults()
 {
-    double *lambda = m_currentCP->getF();
-    double **w = m_currentCP->getW();
-    double *dfree = m_currentCP->getDfree();
+    SReal *lambda = m_currentCP->getF();
+    SReal **w = m_currentCP->getW();
+    SReal *dfree = m_currentCP->getDfree();
 
     solver::module::QPInverseProblem::QPConstraintLists* qpCLists = m_currentCP->getQPConstraintLists();
 
-    unsigned int nbActuatorRows = qpCLists->actuatorRowIds.size();
-    unsigned int nbEffectorRows = qpCLists->effectorRowIds.size();
-    unsigned int nbSensorRows   = qpCLists->sensorRowIds.size();
-    unsigned int nbContactRows  = qpCLists->contactRowIds.size();
-    unsigned int nbEqualityRows = qpCLists->equalityRowIds.size();
-    unsigned int nbRows = nbEffectorRows + nbActuatorRows + nbContactRows + nbSensorRows + nbEqualityRows;
+    std::size_t nbActuatorRows = qpCLists->actuatorRowIds.size();
+    std::size_t nbEffectorRows = qpCLists->effectorRowIds.size();
+    std::size_t nbSensorRows   = qpCLists->sensorRowIds.size();
+    std::size_t nbContactRows  = qpCLists->contactRowIds.size();
+    std::size_t nbEqualityRows = qpCLists->equalityRowIds.size();
+    std::size_t nbRows = nbEffectorRows + nbActuatorRows + nbContactRows + nbSensorRows + nbEqualityRows;
 
     solver::module::QPInverseProblemImpl::QPSystem* qpSystem = m_currentCP->getQPSystem();
     qpSystem->delta.resize(nbRows);
-    for(unsigned int i=0; i<nbRows; i++)
+    for(std::size_t i=0; i<nbRows; i++)
     {
         qpSystem->delta[i] = dfree[i];
-        for(unsigned int j=0; j<nbRows; j++)
+        for(std::size_t j=0; j<nbRows; j++)
             qpSystem->delta[i] += lambda[j]*w[i][j];
     }
 

--- a/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.h
+++ b/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.h
@@ -1,0 +1,49 @@
+/******************************************************************************
+*                              SofaPython3 plugin                             *
+*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+* Contact information: contact@sofa-framework.org                             *
+******************************************************************************/
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+
+#include <SoftRobots.Inverse/component/solver/QPInverseProblemSolver.h>
+
+namespace softrobotsinverse::python3 {
+
+class QPInverseProblemSolver_Trampoline : public softrobotsinverse::solver::QPInverseProblemSolver
+{
+public:
+    SOFA_CLASS(QPInverseProblemSolver_Trampoline, softrobotsinverse::solver::QPInverseProblemSolver);
+
+    /* Inherit the constructors */
+    using softrobotsinverse::solver::QPInverseProblemSolver::QPInverseProblemSolver;
+
+    bool solveSystem();
+
+    bool solveSystem(const sofa::core::ConstraintParams* cParams,
+                     sofa::core::MultiVecId res1,
+                     sofa::core::MultiVecId res2=sofa::core::MultiVecId::null()) override;
+
+    std::string getClassName() const override;
+};
+
+void moduleAddQPInverseProblemSolver(pybind11::module &m);
+
+} /// namespace 
+

--- a/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.h
+++ b/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.h
@@ -1,6 +1,6 @@
 /******************************************************************************
-*                              SofaPython3 plugin                             *
-*                  (c) 2021 CNRS, University of Lille, INRIA                  *
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
 *                                                                             *
 * This program is free software; you can redistribute it and/or modify it     *
 * under the terms of the GNU Lesser General Public License as published by    *
@@ -15,9 +15,17 @@
 * You should have received a copy of the GNU Lesser General Public License    *
 * along with this program. If not, see <http://www.gnu.org/licenses/>.        *
 *******************************************************************************
-* Contact information: contact@sofa-framework.org                             *
+*                       Plugin SoftRobots.Inverse                             *
+*                                                                             *
+* This plugin is distributed under the GNU AGPL v3 (Affero General            *
+* Public License) license.                                                    *
+*                                                                             *
+* Authors: Christian Duriez, Eulalie Coevoet, Yinoussa Adagolodjo             *
+*                                                                             *
+* (c) 2023 INRIA                                                              *
+*                                                                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
 ******************************************************************************/
-
 #pragma once
 
 #include <pybind11/pybind11.h>
@@ -41,6 +49,9 @@ public:
                      sofa::core::MultiVecId res2=sofa::core::MultiVecId::null()) override;
 
     std::string getClassName() const override;
+
+protected:
+    void storeResults();
 };
 
 void moduleAddQPInverseProblemSolver(pybind11::module &m);

--- a/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver_doc.h
+++ b/src/SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver_doc.h
@@ -1,0 +1,53 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+*                       Plugin SoftRobots.Inverse                             *
+*                                                                             *
+* This plugin is distributed under the GNU AGPL v3 (Affero General            *
+* Public License) license.                                                    *
+*                                                                             *
+* Authors: Christian Duriez, Eulalie Coevoet, Yinoussa Adagolodjo             *
+*                                                                             *
+* (c) 2023 INRIA                                                              *
+*                                                                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+******************************************************************************/
+#pragma once
+
+namespace softrobotsinverse::python3::doc
+{
+static auto QPInverseProblemSolver = R"(
+        An Interface to write your own solver.
+
+        Typical usage example:
+
+        import Sofa.SoftRobotsInverse
+
+
+        class MyQPInverseProblemSolver(Sofa.SoftRobotsInverse.QPInverseProblemSolver):
+
+            def __init__(self, *args, **kwargs):
+                Sofa.SoftRobotsInverse.QPInverseProblemSolver.__init__(self, *args, **kwargs)
+
+            def solveSystem(self):
+                W = self.W()
+                dfree = self.dfree()
+                forces = self.lambda_force()  # pointer on lambda
+                forces = my_resolution()
+                return True
+         )";
+}

--- a/src/SoftRobots.Inverse/binding/CMakeLists.txt
+++ b/src/SoftRobots.Inverse/binding/CMakeLists.txt
@@ -1,0 +1,26 @@
+project(SoftRobotsInverseBindings)
+
+set(HEADER_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_QPInverseProblemSolver.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_QPInverseProblemSolver_doc.h
+)
+
+set(SOURCE_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/Binding_QPInverseProblemSolver.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Module_SoftRobotsInverse.cpp
+)
+
+if (NOT TARGET SofaPython3::Plugin)
+    find_package(SofaPython3 REQUIRED COMPONENTS Plugin Bindings.Sofa)
+endif()
+
+SP3_add_python_module(
+    TARGET       ${PROJECT_NAME}
+    PACKAGE      Bindings.Modules
+    MODULE       SoftRobotsInverse
+    DESTINATION  Sofa
+    SOURCES      ${SOURCE_FILES}
+    HEADERS      ${HEADER_FILES}
+    DEPENDS      SofaPython3::Plugin SofaPython3::Bindings.Sofa Sofa.GL SoftRobots.Inverse
+)
+message("-- SofaPython3 bindings for SoftRobots.Inverse will be created.")

--- a/src/SoftRobots.Inverse/binding/Module_SoftRobotsInverse.cpp
+++ b/src/SoftRobots.Inverse/binding/Module_SoftRobotsInverse.cpp
@@ -1,0 +1,44 @@
+/******************************************************************************
+*                 SOFA, Simulation Open-Framework Architecture                *
+*                    (c) 2006 INRIA, USTL, UJF, CNRS, MGH                     *
+*                                                                             *
+* This program is free software; you can redistribute it and/or modify it     *
+* under the terms of the GNU Lesser General Public License as published by    *
+* the Free Software Foundation; either version 2.1 of the License, or (at     *
+* your option) any later version.                                             *
+*                                                                             *
+* This program is distributed in the hope that it will be useful, but WITHOUT *
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or       *
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License *
+* for more details.                                                           *
+*                                                                             *
+* You should have received a copy of the GNU Lesser General Public License    *
+* along with this program. If not, see <http://www.gnu.org/licenses/>.        *
+*******************************************************************************
+*                       Plugin SoftRobots.Inverse                             *
+*                                                                             *
+* This plugin is distributed under the GNU AGPL v3 (Affero General            *
+* Public License) license.                                                    *
+*                                                                             *
+* Authors: Christian Duriez, Eulalie Coevoet, Yinoussa Adagolodjo             *
+*                                                                             *
+* (c) 2023 INRIA                                                              *
+*                                                                             *
+* Contact information: https://project.inria.fr/softrobot/contact/            *
+******************************************************************************/
+
+#include <pybind11/pybind11.h>
+#include <SoftRobots.Inverse/binding/Binding_QPInverseProblemSolver.h>
+
+
+namespace py { using namespace pybind11; }
+
+namespace softrobotsinverse::python3
+{
+
+PYBIND11_MODULE(SoftRobotsInverse, m)
+{
+    moduleAddQPInverseProblemSolver(m);
+}
+
+} // namespace 

--- a/src/SoftRobots.Inverse/component/solver/modules/QPInverseProblem.cpp
+++ b/src/SoftRobots.Inverse/component/solver/modules/QPInverseProblem.cpp
@@ -132,7 +132,7 @@ void QPInverseProblem::storeResults(const vector<double> &x)
     unsigned int nbEffectorRows = m_qpCLists->effectorRowIds.size();
     unsigned int nbSensorRows   = m_qpCLists->sensorRowIds.size();
     unsigned int nbContactRows  = m_qpCLists->contactRowIds.size();
-    unsigned int nbEqualityRows     = m_qpCLists->equalityRowIds.size();
+    unsigned int nbEqualityRows = m_qpCLists->equalityRowIds.size();
     unsigned int nbRows = nbEffectorRows + nbActuatorRows + nbContactRows + nbSensorRows + nbEqualityRows;
 
     m_qpSystem->delta.resize(nbRows);

--- a/src/SoftRobots.Inverse/component/solver/modules/QPInverseProblem.h
+++ b/src/SoftRobots.Inverse/component/solver/modules/QPInverseProblem.h
@@ -120,6 +120,7 @@ class SOFA_SOFTROBOTS_INVERSE_API QPInverseProblem : public sofa::component::con
     QPSystem* getQPSystem() {return m_qpSystem;}
     QPConstraintLists* getQPConstraintLists() {return m_qpCLists;}
 
+    void sendResults();
 
 protected:
 
@@ -142,7 +143,6 @@ protected:
     double   m_time{0.};
 
     void storeResults(const sofa::type::vector<double> &x);
-    void sendResults();
 
 public:
     Eigen::MatrixXd getQPMatriceQ(){


### PR DESCRIPTION
Usage example:

```python
import Sofa.SoftRobotsInverse

class MyQPInverseProblemSolver(Sofa.SoftRobotsInverse.QPInverseProblemSolver):

    def __init__(self, *args, **kwargs):
        Sofa.SoftRobotsInverse.QPInverseProblemSolver.__init__(self, *args, **kwargs)

    def solveSystem(self):
        W = self.W()
        dfree = self.dfree()
        forces = self.lambda_force()  # pointer on lambda
        [...] # solve the problem and store the result in forces
        return True

def createScene(rootnode):
    rootnode.addObject(MyQPInverseProblemSolver)
    [...]
```