### PR TITLE
[cmake] store qpoases include dir path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,7 @@ add_subdirectory(${OASES_LIBRARY_DIRECTORY} extlibs/libqpOASES)
 find_package(libqpOASES REQUIRED)
 message("libqpOASES_INCLUDE_DIRS = ${libqpOASES_INCLUDE_DIRS}")
 include_directories(${libqpOASES_INCLUDE_DIRS})
+set(QPOASES_INCLUDE_DIR ${libqpOASES_INCLUDE_DIRS} CACHE INTERNAL "")
 sofa_install_libraries(PATHS ${libqpOASES_LIBRARY})
 
 option(SOFTROBOTSINVERSE_INSTALL_HEADERS "Install the headers" ON)


### PR DESCRIPTION
I'm working on a GUI to pilot and program soft robots, so I have a dependency with the plugin SoftRobots.Inverse, and I need the path to the solver library. 