### PR TITLE
Fix module name

### DIFF
--- a/src/SoftRobots.Inverse/component/constraint/CableActuator.cpp
+++ b/src/SoftRobots.Inverse/component/constraint/CableActuator.cpp
@@ -30,6 +30,7 @@
 
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/component/statecontainer/MechanicalObject.h>
+#include <SoftRobots.Inverse/component/config.h>
 #include <sofa/core/ObjectFactory.h>
 
 #include <SoftRobots.Inverse/component/constraint/CableActuator.inl>

--- a/src/SoftRobots.Inverse/component/constraint/CableEffector.cpp
+++ b/src/SoftRobots.Inverse/component/constraint/CableEffector.cpp
@@ -30,6 +30,7 @@
 
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/component/statecontainer/MechanicalObject.h>
+#include <SoftRobots.Inverse/component/config.h>
 #include <sofa/core/ObjectFactory.h>
 using namespace sofa::defaulttype;
 using namespace sofa::helper;
@@ -40,7 +41,7 @@ using namespace sofa::core;
 namespace softrobotsinverse::constraint
 {
 
-int CableEffectorClass = RegisterObject("Simulate cable sensor to meassure lengths.")
+int CableEffectorClass = RegisterObject("Simulate cable sensor to measure lengths.")
 .add< CableEffector<Vec3Types> >(true)
 ;
 

--- a/src/SoftRobots.Inverse/component/constraint/CableEquality.cpp
+++ b/src/SoftRobots.Inverse/component/constraint/CableEquality.cpp
@@ -30,6 +30,7 @@
 
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/component/statecontainer/MechanicalObject.h>
+#include <SoftRobots.Inverse/component/config.h>
 #include <sofa/core/ObjectFactory.h>
 
 #include <SoftRobots.Inverse/component/constraint/CableEquality.inl>

--- a/src/SoftRobots.Inverse/component/constraint/PositionEffector.cpp
+++ b/src/SoftRobots.Inverse/component/constraint/PositionEffector.cpp
@@ -27,6 +27,7 @@
 * Contact information: https://project.inria.fr/softrobot/contact/            *
 ******************************************************************************/
 #define SOFTROBOTS_INVERSE_POSITIONEFFECTOR_CPP
+#include <SoftRobots.Inverse/component/config.h>
 #include <sofa/core/ObjectFactory.h>
 #include <SoftRobots.Inverse/component/constraint/PositionEffector.inl>
 

--- a/src/SoftRobots.Inverse/component/constraint/SlidingActuator.cpp
+++ b/src/SoftRobots.Inverse/component/constraint/SlidingActuator.cpp
@@ -29,6 +29,7 @@
 #define SOFTROBOTSINVERSE_CONSTRAINT_SLIDINGACTUATOR_CPP
 
 #include <sofa/defaulttype/VecTypes.h>
+#include <SoftRobots.Inverse/component/config.h>
 #include <sofa/core/ObjectFactory.h>
 using namespace sofa::defaulttype;
 using namespace sofa::helper;
@@ -69,7 +70,7 @@ void SlidingActuator<Rigid3Types>::initDatas()
 
 
 int SlidingActuatorClass = RegisterObject("This component simulates a force exerted along a given direction to solve an inverse problem. \n"
-                                          "In case of Rigid template, it additionaly simulates a force in rotation: the size of 'direction' is equal to 6,\n"
+                                          "In case of Rigid template, it additionally simulates a force in rotation: the size of 'direction' is equal to 6,\n"
                                           "the three first component give the direction in translation and the three last the axe of rotation.")
 .add< SlidingActuator<Vec3Types> >(true)
 .add< SlidingActuator<Rigid3Types> >()

--- a/src/SoftRobots.Inverse/component/constraint/VolumeEffector.cpp
+++ b/src/SoftRobots.Inverse/component/constraint/VolumeEffector.cpp
@@ -29,6 +29,7 @@
 #define SOFTROBOTS_INVERSE_VOLUMEEFFECTOR_CPP
 #include <sofa/defaulttype/VecTypes.h>
 #include <sofa/component/statecontainer/MechanicalObject.h>
+#include <SoftRobots.Inverse/component/config.h>
 #include <sofa/core/ObjectFactory.h>
 using namespace sofa::defaulttype;
 using namespace sofa::helper;

--- a/src/SoftRobots.Inverse/component/solver/QPInverseProblemSolver.cpp
+++ b/src/SoftRobots.Inverse/component/solver/QPInverseProblemSolver.cpp
@@ -30,6 +30,7 @@
 #include <sofa/component/constraint/lagrangian/solver/ConstraintSolverImpl.h>
 #include <sofa/component/constraint/lagrangian/solver/visitors/ConstraintStoreLambdaVisitor.h>
 
+#include <SoftRobots.Inverse/component/config.h>
 #include <sofa/core/ObjectFactory.h>
 #include <sofa/core/visual/VisualParams.h>
 #include <sofa/core/behavior/MultiVec.h>


### PR DESCRIPTION
Fix the warnings:

```
[WARNING] [ObjectFactory] Module name cannot be found when registering CableEffector<Vec3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering PositionEffector<Vec1d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering PositionEffector<Vec2d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering PositionEffector<Vec3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering PositionEffector<Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering VolumeEffector<Vec3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering CableActuator<Vec3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering SlidingActuator<Vec3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering SlidingActuator<Rigid3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering CableEquality<Vec3d> into the object factory
[WARNING] [ObjectFactory] Module name cannot be found when registering QPInverseProblemSolver<> into the object factory
```