### PR TITLE
[examples-tests] cleans scenes, fixes warnings

### DIFF
--- a/examples/sofapython3/component/constraint/ForcePointActuator/Tissues.py
+++ b/examples/sofapython3/component/constraint/ForcePointActuator/Tissues.py
@@ -5,6 +5,41 @@ path = os.path.dirname(os.path.abspath(__file__)) + '/mesh/'
 def createScene(rootNode):
     rootNode.addObject('RequiredPlugin', name='SoftRobots')
     rootNode.addObject('RequiredPlugin', name='SoftRobots.Inverse')
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.AnimationLoop')  # Needed to use components [FreeMotionAnimationLoop]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Collision.Detection.Algorithm')  # Needed to use components [BVHNarrowPhase,BruteForceBroadPhase,CollisionPipeline]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Collision.Detection.Intersection')  # Needed to use components [LocalMinDistance]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Collision.Geometry')  # Needed to use components [LineCollisionModel,PointCollisionModel,SphereCollisionModel,TriangleCollisionModel]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Collision.Response.Contact')  # Needed to use components [CollisionResponse]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Constraint.Lagrangian.Correction')  # Needed to use components [LinearSolverConstraintCorrection,UncoupledConstraintCorrection]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Constraint.Projective')  # Needed to use components [FixedProjectiveConstraint]  
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Engine.Select')  # Needed to use components [BoxROI]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.IO.Mesh')  # Needed to use components [MeshSTLLoader,MeshVTKLoader]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.LinearSolver.Direct')  # Needed to use components [SparseLDLSolver]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.LinearSolver.Iterative')  # Needed to use components [CGLinearSolver]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Mapping.Linear')  # Needed to use components [BarycentricMapping]  
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Mass')  # Needed to use components [UniformMass]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.ODESolver.Backward')  # Needed to use components [EulerImplicitSolver]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.SolidMechanics.FEM.Elastic')  # Needed to use components [TetrahedronFEMForceField]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.StateContainer')  # Needed to use components [MechanicalObject]  
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Topology.Container.Constant')  # Needed to use components [MeshTopology]  
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Visual')  # Needed to use components [VisualStyle]  
+    rootNode.addObject('RequiredPlugin', name='Sofa.GL.Component.Rendering3D')  # Needed to use components [OglModel]  
+    
     rootNode.addObject('VisualStyle',
                        displayFlags='hideWireframe showVisualModels showBehaviorModels hideCollisionModels '
                                     'hideBoundingCollisionModels hideForceFields showInteractionForceFields')
@@ -14,10 +49,10 @@ def createScene(rootNode):
 
     rootNode.addObject('FreeMotionAnimationLoop')
     rootNode.addObject('QPInverseProblemSolver', printLog=False, epsilon=1e-3, tolerance=1e-4, maxIterations=2500)
-    rootNode.addObject('DefaultPipeline')
+    rootNode.addObject('CollisionPipeline')
     rootNode.addObject('BruteForceBroadPhase')
     rootNode.addObject('BVHNarrowPhase')
-    rootNode.addObject('DefaultContactManager', response="FrictionContactConstraint", responseParams="mu=0")
+    rootNode.addObject('CollisionResponse', response="FrictionContactConstraint", responseParams="mu=0")
     rootNode.addObject('LocalMinDistance', name="Proximity", alarmDistance=5, contactDistance=3)
 
     ##########################################
@@ -26,7 +61,7 @@ def createScene(rootNode):
     goal = rootNode.addChild('goal')
     goal.addObject('VisualStyle', displayFlags='showCollisionModels')
     goal.addObject('EulerImplicitSolver', firstOrder=True)
-    goal.addObject('CGLinearSolver', iterations=100)
+    goal.addObject('CGLinearSolver', iterations=100, tolerance=1e-5, threshold=1e-5)
     goal.addObject('MechanicalObject', name='goalMO', showObject=True, showObjectScale=10, drawMode=1,
                    showColor=[255, 255, 255, 255], position=[40, 30, 30])
     goal.addObject('SphereCollisionModel', radius=10, group=[0, 1, 2])
@@ -44,7 +79,7 @@ def createScene(rootNode):
     model.addObject('UniformMass', totalMass=0.03)
     model.addObject('TetrahedronFEMForceField', poissonRatio=0.3, youngModulus=180)
     model.addObject('BoxROI', name='boxROI', box=[0, 50, -20, 10, 70, 20], drawBoxes=False)
-    model.addObject('FixedConstraint', indices='@boxROI.indices')
+    model.addObject('FixedProjectiveConstraint', indices='@boxROI.indices')
     model.addObject('LinearSolverConstraintCorrection')
 
     ##########################################
@@ -60,8 +95,8 @@ def createScene(rootNode):
     skin.addObject('TetrahedronFEMForceField', poissonRatio=0.3, youngModulus=180)
     skin.addObject('BoxROI', name='boxROI1', box=[-100, -5, -30, -90, 5, 30], drawBoxes=False)
     skin.addObject('BoxROI', name='boxROI2', box=[100, -5, -30, 90, 5, 30], drawBoxes=False)
-    skin.addObject('FixedConstraint', name='fix_1', indices='@boxROI1.indices')
-    skin.addObject('FixedConstraint', name='fix_2', indices='@boxROI2.indices')
+    skin.addObject('FixedProjectiveConstraint', name='fix_1', indices='@boxROI1.indices')
+    skin.addObject('FixedProjectiveConstraint', name='fix_2', indices='@boxROI2.indices')
     skin.addObject('LinearSolverConstraintCorrection')
 
     ##########################################

--- a/examples/sofapython3/component/constraint/SlidingActuator/actuatedBeam.py
+++ b/examples/sofapython3/component/constraint/SlidingActuator/actuatedBeam.py
@@ -10,6 +10,27 @@ def createScene(rootNode):
     rootNode.addObject('RequiredPlugin', name='BeamAdapter')
     rootNode.addObject('RequiredPlugin', name='SoftRobots')
     rootNode.addObject('RequiredPlugin', name='SoftRobots.Inverse')
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.AnimationLoop')  # Needed to use components [FreeMotionAnimationLoop]
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Constraint.Lagrangian.Correction')  # Needed to use components [GenericConstraintCorrection,UncoupledConstraintCorrection]
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Constraint.Projective')  # Needed to use components [PartialFixedProjectiveConstraint]
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.LinearSolver.Direct')  # Needed to use components [SparseLDLSolver]
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.LinearSolver.Iterative')  # Needed to use components [CGLinearSolver]
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Mapping.NonLinear')  # Needed to use components [RigidMapping]
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.ODESolver.Backward')  # Needed to use components [EulerImplicitSolver]
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.SolidMechanics.Spring')  # Needed to use components [RestShapeSpringsForceField]
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.StateContainer')  # Needed to use components [MechanicalObject]
+    rootNode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Topology.Container.Constant')  # Needed to use components [MeshTopology]
+    rootNode.addObject('RequiredPlugin', name='Sofa.Component.Visual')  # Needed to use components [VisualStyle]
     rootNode.addObject('VisualStyle', displayFlags='showVisualModels showBehaviorModels showCollisionModels '
                                                    'showForceFields showInteractionForceFields')
 
@@ -46,10 +67,10 @@ def createScene(rootNode):
 
     model.addObject('BeamInterpolation', dofsAndBeamsAligned=True, straight=False, defaultYoungModulus=100, radius=0.5)
     model.addObject('AdaptiveBeamForceFieldAndMass', computeMass=True, massDensity=0.000001)
-    # Unfortunatly, the component SlidingActuator needs to be used with a PartialFixedConstraint.
+    # Unfortunatly, the component SlidingActuator needs to be used with a PartialFixedProjectiveConstraint.
     # Ex: if SlidingActuator simulates a single dof (e.g. translation along x),
     # the other dofs must be fixed using this component
-    model.addObject('PartialFixedConstraint', indices=0, fixedDirections=[0, 1, 1, 1, 1, 0])
+    model.addObject('PartialFixedProjectiveConstraint', indices=0, fixedDirections=[0, 1, 1, 1, 1, 0])
     model.addObject('RestShapeSpringsForceField', points=0, angularStiffness=1000, stiffness=1000)
 
     ##########################################

--- a/examples/sofapython3/component/constraint/SlidingActuator/actuatedRigidCube.py
+++ b/examples/sofapython3/component/constraint/SlidingActuator/actuatedRigidCube.py
@@ -2,6 +2,26 @@ def createScene(rootnode):
     from splib3.animation import animate, AnimationManager
     rootnode.addObject(AnimationManager(rootnode))
     rootnode.addObject('RequiredPlugin', pluginName=['SoftRobots', 'SoftRobots.Inverse', 'SofaPython3'])
+    rootnode.addObject('RequiredPlugin',
+                   name='Sofa.Component.AnimationLoop')  # Needed to use components [FreeMotionAnimationLoop]  
+    rootnode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Constraint.Lagrangian.Correction')  # Needed to use components [GenericConstraintCorrection,UncoupledConstraintCorrection]  
+    rootnode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Constraint.Projective')  # Needed to use components [PartialFixedProjectiveConstraint]  
+    rootnode.addObject('RequiredPlugin', name='Sofa.Component.IO.Mesh')  # Needed to use components [MeshOBJLoader]  
+    rootnode.addObject('RequiredPlugin',
+                   name='Sofa.Component.LinearSolver.Direct')  # Needed to use components [SparseLDLSolver]  
+    rootnode.addObject('RequiredPlugin',
+                   name='Sofa.Component.LinearSolver.Iterative')  # Needed to use components [CGLinearSolver]  
+    rootnode.addObject('RequiredPlugin',
+                   name='Sofa.Component.Mapping.NonLinear')  # Needed to use components [RigidMapping]  
+    rootnode.addObject('RequiredPlugin', name='Sofa.Component.Mass')  # Needed to use components [UniformMass]  
+    rootnode.addObject('RequiredPlugin',
+                   name='Sofa.Component.ODESolver.Backward')  # Needed to use components [EulerImplicitSolver]  
+    rootnode.addObject('RequiredPlugin',
+                   name='Sofa.Component.StateContainer')  # Needed to use components [MechanicalObject]  
+    rootnode.addObject('RequiredPlugin', name='Sofa.GL.Component.Rendering3D')  # Needed to use components [OglModel] 
+    
     rootnode.gravity = [0, 0, 0]
     rootnode.addObject('DefaultVisualManagerLoop')
     rootnode.addObject('FreeMotionAnimationLoop')
@@ -14,8 +34,8 @@ def createScene(rootnode):
     cube.addObject('GenericConstraintCorrection')
     cube.addObject('MechanicalObject', template='Rigid3', position=[-10, 0, 0, 0, 0, 0, 1])
     cube.addObject('UniformMass', totalMass=0.01)
-    # SlidingActuator needs a PartialFixedConstraint to fix the other directions
-    cube.addObject('PartialFixedConstraint', template='Rigid3', fixedDirections=[0, 1, 1, 1, 1, 1])
+    # SlidingActuator needs a PartialFixedProjectiveConstraint to fix the other directions
+    cube.addObject('PartialFixedProjectiveConstraint', template='Rigid3', fixedDirections=[0, 1, 1, 1, 1, 1])
     cube.addObject('SlidingActuator', template='Rigid3', indices=0, direction=[1, 0, 0, 0, 0, 0], maxDispVariation=0.1)
 
     visual = cube.addChild('Visu')
@@ -35,7 +55,7 @@ def createScene(rootnode):
     target.addObject('EulerImplicitSolver', firstOrder=True)
     target.addObject('CGLinearSolver', tolerance=1e-5, iterations=20, threshold=1e-5)
     target.addObject('MechanicalObject', position=[30, 0, 0], showObject=True, drawMode=2, showObjectScale=3)
-    target.addObject('PartialFixedConstraint', fixedDirections=[0, 1, 1])
+    target.addObject('PartialFixedProjectiveConstraint', fixedDirections=[0, 1, 1])
     target.addObject('UniformMass', totalMass=0.1)
     target.addObject('UncoupledConstraintCorrection')
 

--- a/examples/xml/component/constraint/PositionEffector/PositionEffector_Rigid.scn
+++ b/examples/xml/component/constraint/PositionEffector/PositionEffector_Rigid.scn
@@ -4,13 +4,27 @@
     <RequiredPlugin name="SoftRobots"/>
     <RequiredPlugin name="SoftRobots.Inverse"/>
     <RequiredPlugin name="BeamAdapter"/>
+    <RequiredPlugin name="Sofa.Component.AnimationLoop"/> <!-- Needed to use components [FreeMotionAnimationLoop] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Detection.Algorithm"/> <!-- Needed to use components [BVHNarrowPhase,BruteForceBroadPhase] -->  
+    <RequiredPlugin name="Sofa.Component.Collision.Detection.Intersection"/> <!-- Needed to use components [MinProximityIntersection] -->  
+    <RequiredPlugin name="Sofa.Component.Constraint.Lagrangian.Correction"/> <!-- Needed to use components [LinearSolverConstraintCorrection] -->  
+    <RequiredPlugin name="Sofa.Component.Constraint.Projective"/> <!-- Needed to use components [FixedProjectiveConstraint] -->  
+    <RequiredPlugin name="Sofa.Component.LinearSolver.Direct"/> <!-- Needed to use components [BTDLinearSolver] -->  
+    <RequiredPlugin name="Sofa.Component.Mapping.Linear"/> <!-- Needed to use components [BeamLinearMapping] -->  
+    <RequiredPlugin name="Sofa.Component.ODESolver.Backward"/> <!-- Needed to use components [EulerImplicitSolver] -->  
+    <RequiredPlugin name="Sofa.Component.SceneUtility"/> <!-- Needed to use components [InfoComponent] -->  
+    <RequiredPlugin name="Sofa.Component.StateContainer"/> <!-- Needed to use components [MechanicalObject] -->  
+    <RequiredPlugin name="Sofa.Component.Topology.Container.Constant"/> <!-- Needed to use components [CubeTopology,MeshTopology] -->  
+    <RequiredPlugin name="Sofa.Component.Visual"/> <!-- Needed to use components [VisualStyle] -->  
+    <RequiredPlugin name="Sofa.GL.Component.Rendering3D"/> <!-- Needed to use components [OglModel] -->
+    <RequiredPlugin name="Sofa.Component.Collision.Response.Contact"/> <!-- Needed to use components [CollisionResponse] -->
 
     <VisualStyle displayFlags="showForceFields showCollisionModels showBehavior" />
-    <DefaultPipeline depth="6" verbose="0" draw="0" />
+    <CollisionPipeline depth="6" verbose="0" draw="0" />
     <BruteForceBroadPhase />
     <BVHNarrowPhase/>
     <MinProximityIntersection name="Proximity" alarmDistance="0.03" contactDistance="0.02" />
-    <DefaultContactManager/>
+    <CollisionResponse/>
     <FreeMotionAnimationLoop/>
     <QPInverseProblemSolver printLog='0'/>
 
@@ -47,7 +61,7 @@
 	        <BeamLinearMapping />
         </Node>
 
-        <FixedConstraint name="FixedConstraint" indices="0" />
+        <FixedProjectiveConstraint name="FixedProjectiveConstraint" indices="0" />
         <AdaptiveBeamForceFieldAndMass name="FEM"/>
 
         <Node name="Visual">

--- a/tests/component/solver/scenes/CubeOnFloor.pyscn
+++ b/tests/component/solver/scenes/CubeOnFloor.pyscn
@@ -12,10 +12,10 @@ def createScene(rootNode):
 
                 rootNode.addObject('FreeMotionAnimationLoop')
                 rootNode.addObject('QPInverseProblemSolver', epsilon=0, maxIterations=1000, tolerance=1e-5)
-                rootNode.addObject('DefaultPipeline')
+                rootNode.addObject('CollisionPipeline')
                 rootNode.addObject('BruteForceBroadPhase')
                 rootNode.addObject('BVHNarrowPhase')
-                rootNode.addObject('DefaultContactManager', response="FrictionContactConstraint", responseParams="mu=0.6")
+                rootNode.addObject('CollisionResponse', response="FrictionContactConstraint", responseParams="mu=0.6")
                 rootNode.addObject('LocalMinDistance', alarmDistance=3, contactDistance=1)
 
                 rootNode.addObject('OglSceneFrame', style="Arrows", alignment="TopRight")


### PR DESCRIPTION
In this PR:
- Cleaning of `JointActuator.py`: no needs of the beam, use a `Vec3` target to be able to move it with the mouse
- `DefaultPipeline` -> `CollisionPipeline`
- `DefaultContactManager` -> `CollisionResponse`
- `FixedConstraint` -> `FixedProjectiveConstraint`
- Adds missing required data for `CGLinearSolver`
- Adds some `RequiredPlugin`