### PR TITLE
Fix usage of proxsuite is lib used as 3rd party

### DIFF
--- a/SoftRobots.InverseConfig.cmake.in
+++ b/SoftRobots.InverseConfig.cmake.in
@@ -10,7 +10,9 @@ find_package(Sofa.Component.SolidMechanics.FEM.Elastic QUIET REQUIRED)
 find_package(libqpOASES REQUIRED)
 include_directories(${OASES_INCLUDE_DIRS})
 
-find_package(proxsuite REQUIRED)
+if(SOFTROBOTSINVERSE_ENABLE_PROXQP)
+  find_package(proxsuite QUIET REQUIRED)
+endif()
 
 if(NOT TARGET @PROJECT_NAME@)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Fixes bug introduced by #49 when using `SoftRobots.Inverse` as a third party library and without `proxQP` support (i.e. if `proxsuite` is not available as dependency).