### PR TITLE
Remove call to SetUp

### DIFF
--- a/tests/component/solver/QPInverseProblemSolverTest.cpp
+++ b/tests/component/solver/QPInverseProblemSolverTest.cpp
@@ -88,8 +88,6 @@ struct QPInverseProblemSolverTest : public BaseTest,
     {
         helper::system::TemporaryLocale locale(LC_NUMERIC, "C");
 
-        SetUp();
-
         sofa::simulation::node::initRoot(m_root.get());
 
         int nbTimeStep = 10;
@@ -134,8 +132,6 @@ struct QPInverseProblemSolverTest : public BaseTest,
 
     void regressionTests(const std::string& qpSolver)
     {
-        SetUp();
-
         sofa::simulation::node::initRoot(m_root.get());
         string deltaString, lambdaString;
 


### PR DESCRIPTION
Since the test inherits from `BaseTest`, `SetUp` is called in any case. I don't think it's necessary to call it again. And `SetUp` is no longer accessible (it's now private in `BaseTest`).