### PR TITLE
[CMake, qpOASES] Update min cmake version for extlib qpOASES

### DIFF
--- a/extlibs/qpOASES-3.2.0/CMakeLists.txt
+++ b/extlibs/qpOASES-3.2.0/CMakeLists.txt
@@ -29,7 +29,7 @@
 ##     Date:      2007-2015
 ##
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 
 project(libqpOASES VERSION 1.0)
 SET(PACKAGE_NAME "libqpOASES")


### PR DESCRIPTION
Due to deprecated warnings which become errors with cmake 4.0 (compatibility with cmake < 3.5 is removed)
