### PR TITLE
Fix branch name in filtering for dashboard notify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           ./bin/SoftRobots.Inverse_test${{ steps.sofa.outputs.exe }}
 
       - name: Notify dashboard
-        if: always() && startsWith(github.repository, 'SofaDefrost') && startsWith(github.ref, 'refs/heads/master') # we are not on a fork and on master
+        if: always() && startsWith(github.repository, 'SofaDefrost') && startsWith(github.ref, 'refs/heads/main') # we are not on a fork and on main
         env:
           DASH_AUTH: ${{ secrets.PLUGIN_DASH }}
         shell: bash


### PR DESCRIPTION
Notify dashboard was never executed due to the filtering that was done wrong.