### PR TITLE
[CMake] Change python binding package name

### DIFF
--- a/src/SoftRobots.Inverse/binding/CMakeLists.txt
+++ b/src/SoftRobots.Inverse/binding/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 
 SP3_add_python_module(
     TARGET       ${PROJECT_NAME}
-    PACKAGE      Bindings.Modules
+    PACKAGE      SoftRobots
     MODULE       SoftRobotsInverse
     DESTINATION  Sofa
     SOURCES      ${SOURCE_FILES}


### PR DESCRIPTION
Using the Sofa.Bindings package name forces the binding target to be exported along the SofaPython3 bindings, making one of its target unusable when SoftRobots.Inverse is build along it. This broke the OOT compilation of any plugin depending on SofaPython3 with the release. 

In practice, this shouldn't change anything when using it, you'll still be able to import it using 
```py
import Sofa.SoftRobotsInverse
``` 