### PR TITLE
[extlibs] fixes qpOASES libs conflict

### DIFF
--- a/extlibs/qpOASES-3.2.0/include/qpOASES/Matrices.hpp
+++ b/extlibs/qpOASES-3.2.0/include/qpOASES/Matrices.hpp
@@ -45,24 +45,24 @@
 #ifdef __USE_SINGLE_PRECISION__
 
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define GEMM sgemm_
+	#define GEMM qpoases_sgemm_
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define SYR ssyr_
+	#define SYR qpoases_ssyr_
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define SYR2 ssyr2_
+	#define SYR2 qpoases_ssyr2_
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define POTRF spotrf_
+	#define POTRF qpoases_spotrf_
 
 #else
 
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define GEMM dgemm_
+	#define GEMM qpoases_dgemm_
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define SYR  dsyr_
+	#define SYR  qpoases_dsyr_
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define SYR2 dsyr2_
+	#define SYR2 qpoases_dsyr2_
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define POTRF dpotrf_
+	#define POTRF qpoases_dpotrf_
 
 #endif /* __USE_SINGLE_PRECISION__ */
 
@@ -70,32 +70,32 @@
 extern "C"
 {
 	/** Performs one of the matrix-matrix operation in double precision. */
-	void dgemm_ ( const char*, const char*, const unsigned long*, const unsigned long*, const unsigned long*,
+	void qpoases_dgemm_ ( const char*, const char*, const unsigned long*, const unsigned long*, const unsigned long*,
 			const double*, const double*, const unsigned long*, const double*, const unsigned long*,
 			const double*, double*, const unsigned long* );
 	/** Performs one of the matrix-matrix operation in single precision. */
-	void sgemm_ ( const char*, const char*, const unsigned long*, const unsigned long*, const unsigned long*,
+	void qpoases_sgemm_ ( const char*, const char*, const unsigned long*, const unsigned long*, const unsigned long*,
 			const float*, const float*, const unsigned long*, const float*, const unsigned long*,
 			const float*, float*, const unsigned long* );
 
 	/** Performs a symmetric rank 1 operation in double precision. */
-	void dsyr_ ( const char *, const unsigned long *, const double *, const double *,
+	void qpoases_dsyr_ ( const char *, const unsigned long *, const double *, const double *,
 				 const unsigned long *, double *, const unsigned long *);
 	/** Performs a symmetric rank 1 operation in single precision. */
-	void ssyr_ ( const char *, const unsigned long *, const float *, const float *,
+	void qpoases_ssyr_ ( const char *, const unsigned long *, const float *, const float *,
 				 const unsigned long *, float *, const unsigned long *);
 
 	/** Performs a symmetric rank 2 operation in double precision. */
-	void dsyr2_ ( const char *, const unsigned long *, const double *, const double *,
+	void qpoases_dsyr2_ ( const char *, const unsigned long *, const double *, const double *,
 				  const unsigned long *, const double *, const unsigned long *, double *, const unsigned long *);
 	/** Performs a symmetric rank 2 operation in single precision. */
-	void ssyr2_ ( const char *, const unsigned long *, const float *, const float *,
+	void qpoases_ssyr2_ ( const char *, const unsigned long *, const float *, const float *,
 				  const unsigned long *, const float *, const unsigned long *, float *, const unsigned long *);
 
 	/** Calculates the Cholesky factorization of a real symmetric positive definite matrix in double precision. */
-	void dpotrf_ ( const char *, const unsigned long *, double *, const unsigned long *, long * );
+	void qpoases_dpotrf_ ( const char *, const unsigned long *, double *, const unsigned long *, long * );
 	/** Calculates the Cholesky factorization of a real symmetric positive definite matrix in single precision. */
-	void spotrf_ ( const char *, const unsigned long *, float *, const unsigned long *, long * );
+	void qpoases_spotrf_ ( const char *, const unsigned long *, float *, const unsigned long *, long * );
 }
 
 

--- a/extlibs/qpOASES-3.2.0/include/qpOASES/SQProblemSchur.hpp
+++ b/extlibs/qpOASES-3.2.0/include/qpOASES/SQProblemSchur.hpp
@@ -49,9 +49,9 @@
 	/** Macro for calling level 3 BLAS operation in single precision. */
 	//#define ORMQR sormqr_
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define TRTRS strtrs_
+	#define TRTRS qpoases_strtrs_
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define TRCON strcon_
+	#define TRCON qpoases_strcon_
 
 #else
 
@@ -60,9 +60,9 @@
 	/** Macro for calling level 3 BLAS operation in double precision. */
 	//#define ORMQR dormqr_
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define TRTRS dtrtrs_
+	#define TRTRS qpoases_dtrtrs_
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define TRCON dtrcon_
+	#define TRCON qpoases_dtrcon_
 
 #endif /* __USE_SINGLE_PRECISION__ */
 
@@ -84,17 +84,17 @@ extern "C" {
 					//float *WORK, const unsigned long *LWORK, int *INFO );
 
 	/** Solve a triangular system (double precision) */
-	void dtrtrs_(	const char *UPLO, const char *TRANS, const char *DIAG, const unsigned long *N, const unsigned long *NRHS,
+	void qpoases_dtrtrs_(	const char *UPLO, const char *TRANS, const char *DIAG, const unsigned long *N, const unsigned long *NRHS,
 					double *A, const unsigned long *LDA, double *B, const unsigned long *LDB, long *INFO );
 	/** Solve a triangular system (single precision) */
-	void strtrs_(	const char *UPLO, const char *TRANS, const char *DIAG, const unsigned long *N, const unsigned long *NRHS,
+	void qpoases_strtrs_(	const char *UPLO, const char *TRANS, const char *DIAG, const unsigned long *N, const unsigned long *NRHS,
 					float *A, const unsigned long *LDA, float *B, const unsigned long *LDB, long *INFO );
 
 	/** Estimate the reciprocal of the condition number of a triangular matrix in double precision */
-	void dtrcon_(	const char *NORM, const char *UPLO, const char *DIAG, const unsigned long *N, double *A, const unsigned long *LDA,
+	void qpoases_dtrcon_(	const char *NORM, const char *UPLO, const char *DIAG, const unsigned long *N, double *A, const unsigned long *LDA,
 					double *RCOND, double *WORK, const unsigned long *IWORK, long *INFO );
 	/** Estimate the reciprocal of the condition number of a triangular matrix in single precision */
-	void strcon_(	const char *NORM, const char *UPLO, const char *DIAG, const unsigned long *N, float *A, const unsigned long *LDA,
+	void qpoases_strcon_(	const char *NORM, const char *UPLO, const char *DIAG, const unsigned long *N, float *A, const unsigned long *LDA,
 					float *RCOND, float *WORK, const unsigned long *IWORK, long *INFO );
 }
 

--- a/extlibs/qpOASES-3.2.0/src/BLASReplacement.cpp
+++ b/extlibs/qpOASES-3.2.0/src/BLASReplacement.cpp
@@ -35,11 +35,11 @@
 #include <qpOASES/Utils.hpp>
 
 
-extern "C" void dgemm_(	const char *TRANSA, const char *TRANSB,
-						const unsigned long *M, const unsigned long *N, const unsigned long *K,
-						const double *ALPHA, const double *A, const unsigned long *LDA, const double *B, const unsigned long *LDB,
-						const double *BETA, double *C, const unsigned long *LDC
-						)
+extern "C" void qpoases_dgemm_(	const char *TRANSA, const char *TRANSB,
+								const unsigned long *M, const unsigned long *N, const unsigned long *K,
+								const double *ALPHA, const double *A, const unsigned long *LDA, const double *B, const unsigned long *LDB,
+								const double *BETA, double *C, const unsigned long *LDC
+								)
 {
 	unsigned long i, j, k;
 
@@ -90,11 +90,11 @@ extern "C" void dgemm_(	const char *TRANSA, const char *TRANSB,
 						C[j+(*LDC)*k] += *ALPHA * A[i+(*LDA)*j] * B[i+(*LDB)*k];
 }
 
-extern "C" void sgemm_(	const char *TRANSA, const char *TRANSB,
-						const unsigned long *M, const unsigned long *N, const unsigned long *K,
-						const float *ALPHA, const float *A, const unsigned long *LDA, const float *B, const unsigned long *LDB,
-						const float *BETA, float *C, const unsigned long *LDC
-						)
+extern "C" void qpoases_sgemm_(	const char *TRANSA, const char *TRANSB,
+								const unsigned long *M, const unsigned long *N, const unsigned long *K,
+								const float *ALPHA, const float *A, const unsigned long *LDA, const float *B, const unsigned long *LDB,
+								const float *BETA, float *C, const unsigned long *LDC
+								)
 {
 	unsigned long i, j, k;
 

--- a/extlibs/qpOASES-3.2.0/src/LAPACKReplacement.cpp
+++ b/extlibs/qpOASES-3.2.0/src/LAPACKReplacement.cpp
@@ -118,15 +118,15 @@ extern "C" void qpoases_spotrf_(	const char *uplo, const unsigned long *_n, floa
 		*info = 0;
 }
 
-extern "C" void dtrtrs_(	const char *UPLO, const char *TRANS, const char *DIAG,
-							const unsigned long *N, const unsigned long *NRHS,
-							double *A, const unsigned long *LDA, double *B, const unsigned long *LDB, long *INFO
-							)
+extern "C" void qpoases_dtrtrs_(	const char *UPLO, const char *TRANS, const char *DIAG,
+									const unsigned long *N, const unsigned long *NRHS,
+									double *A, const unsigned long *LDA, double *B, const unsigned long *LDB, long *INFO
+									)
 {
 	; /* Dummy. If SQProblemSchur is to be used, system LAPACK must be used */
 }
 
-extern "C" void strtrs_(	const char *UPLO, const char *TRANS, const char *DIAG,
+extern "C" void qpoases_strtrs_(	const char *UPLO, const char *TRANS, const char *DIAG,
 							const unsigned long *N, const unsigned long *NRHS,
 							float *A, const unsigned long *LDA, float *B, const unsigned long *LDB, long *INFO
 							)
@@ -134,7 +134,7 @@ extern "C" void strtrs_(	const char *UPLO, const char *TRANS, const char *DIAG,
 	; /* Dummy. If SQProblemSchur is to be used, system LAPACK must be used */
 }
 
-extern "C" void dtrcon_(	const char *NORM, const char *UPLO, const char *DIAG,
+extern "C" void qpoases_dtrcon_(	const char *NORM, const char *UPLO, const char *DIAG,
 							const unsigned long *N, double *A, const unsigned long *LDA,
 							double *RCOND, double *WORK, const unsigned long *IWORK, long *INFO
 							)
@@ -142,7 +142,7 @@ extern "C" void dtrcon_(	const char *NORM, const char *UPLO, const char *DIAG,
 	; /* Dummy. If SQProblemSchur is to be used, system LAPACK must be used */
 }
 
-extern "C" void strcon_(	const char *NORM, const char *UPLO, const char *DIAG,
+extern "C" void qpoases_strcon_(	const char *NORM, const char *UPLO, const char *DIAG,
 							const unsigned long *N, float *A, const unsigned long *LDA,
 							float *RCOND, float *WORK, const unsigned long *IWORK, long *INFO
 							)

--- a/extlibs/qpOASES-3.2.0/src/LAPACKReplacement.cpp
+++ b/extlibs/qpOASES-3.2.0/src/LAPACKReplacement.cpp
@@ -35,9 +35,9 @@
 #include <qpOASES/Utils.hpp>
 
 
-extern "C" void dpotrf_(	const char *uplo, const unsigned long *_n, double *a,
-							const unsigned long *_lda, long *info
-							)
+extern "C" void qpoases_dpotrf_(	const char *uplo, const unsigned long *_n, double *a,
+									const unsigned long *_lda, long *info
+									)
 {
 	double sum;
 	long i, j, k;
@@ -77,7 +77,7 @@ extern "C" void dpotrf_(	const char *uplo, const unsigned long *_n, double *a,
 }
 
 
-extern "C" void spotrf_(	const char *uplo, const unsigned long *_n, float *a,
+extern "C" void qpoases_spotrf_(	const char *uplo, const unsigned long *_n, float *a,
 							const unsigned long *_lda, long *info
 							)
 {


### PR DESCRIPTION
**Problem**

qpOASES redefines internally some BLAS/LAPACK functions, and this can create problems if linking with another library that uses BLAS or LAPACK ([from](https://github.com/coin-or/qpOASES/issues/110)). In our case pytorch.

**In this PR**

Renames the functions to avoid the conflict, in the same idea of [this commit](https://github.com/coin-or/qpOASES/commit/bcc825f8f3b853ce76cfb439c63ff8f5c072f895). 