### PR TITLE
Update Conda CI to devel conda packages

### DIFF
--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -60,19 +60,30 @@ jobs:
 
     - name: Configure SoftRobots [Windows]
       if: contains(matrix.os, 'windows')
-      shell: bash -l {0}
+      # It's better to use CMD to have all VS variables setup
+      shell: cmd /C CALL {0}
       run: |
         cd SoftRobots
         mkdir build
         cd build
-        cmake .. -GNinja \
-         -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
-         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-         -DPython_EXECUTABLE:PATH=${CONDA_PREFIX}/python.exe \
+        cmake .. -GNinja ^
+         -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX%/Library ^
+         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ^
+         -DPython_EXECUTABLE:PATH=%CONDA_PREFIX%/python.exe ^
          -DSOFTROBOTS_BUILD_TESTS:BOOL=OFF
 
-    - name: Build & install SoftRobots
+    - name: Build & install SoftRobots [Linux / macOS]
+      if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}
+      run: |
+        cd SoftRobots/build
+        cmake --build . --config ${{ matrix.build_type }} -v -j 2
+        cmake --install . --config ${{ matrix.build_type }}
+
+    - name: Build & install SoftRobots [Windows]
+      if: contains(matrix.os, 'windows')
+      # It's better to use CMD to have all VS variables setup
+      shell: cmd /C CALL {0}
       run: |
         cd SoftRobots/build
         cmake --build . --config ${{ matrix.build_type }} -v -j 2
@@ -116,26 +127,32 @@ jobs:
 
     - name: Configure SoftRobots.Inverse [Windows]
       if: contains(matrix.os, 'windows')
-      shell: bash -l {0}
+      # It's better to use CMD to have all VS variables setup
+      shell: cmd /C CALL {0}
       run: |
         mkdir build
         cd build
-        cmake .. -GNinja $CMAKE_OPTS_QPSOLVER \
-         -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
-         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-         -DPython_EXECUTABLE:PATH=${CONDA_PREFIX}/python.exe \
+        cmake .. -GNinja %CMAKE_OPTS_QPSOLVER% ^
+         -DCMAKE_INSTALL_PREFIX=%CONDA_PREFIX% ^
+         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ^
+         -DPython_EXECUTABLE:PATH=%CONDA_PREFIX%/python.exe  ^
          -DSOFTROBOTSINVERSE_BUILD_TESTS:BOOL=ON
 
-    - name: Build SoftRobots.Inverse
+    - name: Build && install SoftRobots.Inverse [Linux / macOS]
+      if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}
       run: |
         cd build
         cmake --build . --config ${{ matrix.build_type }} -v -j 2
+        cmake --install . --config ${{ matrix.build_type }}
 
-    - name: Install SoftRobots.Inverse
-      shell: bash -l {0}
+    - name: Build && install SoftRobots.Inverse [Windows]
+      if: contains(matrix.os, 'windows')
+      # It's better to use CMD to have all VS variables setup
+      shell: cmd /C CALL {0}
       run: |
         cd build
+        cmake --build . --config ${{ matrix.build_type }} -v -j 2
         cmake --install . --config ${{ matrix.build_type }}
 
     - name: Test SoftRobots.Inverse

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -37,13 +37,13 @@ jobs:
       if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}
       run: |
-        conda install cmake cxx-compiler ninja pkg-config
+        conda install cmake cxx-compiler ninja pkg-config pybind11
 
     - name: Install compilation environment [Windows]
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
-        conda install cmake vs2022_win-64 ninja pkg-config
+        conda install cmake vs2022_win-64 ninja pkg-config pybind11
 
     - name: Checkout SOFA SoftRobots
       uses: actions/checkout@v4

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-14, windows-2022]
-        python_version: ["3.13"]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm]
+        python_version: ["3.12"]
         build_type: ["Release"]
         qp_solver: ["qpOases", "proxQP"]
 
@@ -28,68 +28,69 @@ jobs:
         channels: conda-forge
         conda-remove-defaults: "true"
 
+    - name: Install SOFA and SofaPython3 from devel packages
+      shell: bash -l {0}
+      run: |
+        conda install sofa-devel sofa-python3 -c https://prefix.dev/sofa-framework-devel
+
+    - name: Checkout SOFA SoftRobots
+      uses: actions/checkout@v4
+      with:
+        repository: SofaDefrost/SoftRobots
+        ref: master
+        path: SoftRobots
+
     - name: Checkout source code
       uses: actions/checkout@v4
 
-    - name: Install SOFA from nightly packages [Conda]
+    - name: Install compilation environment [Linux / macOS]
+      if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}
       run: |
-        conda install sofa-devel sofa-python3 sofa-stlib sofa-softrobots -c sofa-framework-nightly
+        conda install cmake cxx-compilers ninja pkg-config
 
-    - name: Install compilation environment [Conda / Linux]
-      if: contains(matrix.os, 'ubuntu')
-      shell: bash -l {0}
-      run: |
-        conda install cmake compilers make ninja      
-        conda install mesa-libgl-devel-cos7-x86_64
-
-    - name: Install compilation environment [Conda / macOS]
-      if: contains(matrix.os, 'macos')
-      shell: bash -l {0}
-      run: |
-        conda install cmake compilers make ninja
-
-    - name: Install compilation environment [Conda / Windows]
+    - name: Install compilation environment [Windows]
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
-        conda install cmake vs2022_win-64
+        conda install cmake vs2022_win-64 ninja pkg-config
 
-    - name: Install dependencies [Conda]
+    - name: Configure, build & install SoftRobots
       shell: bash -l {0}
       run: |
-        conda install eigen libboost-headers pybind11 cxxopts
+        cd SoftRobots
+        mkdir build
+        cd build
+        cmake .. -GNinja \
+         -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
+         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+         -DPython_EXECUTABLE:PATH=${CONDA_PREFIX}/bin/python \
+         -DSOFTROBOTS_BUILD_TESTS:BOOL=OFF
+        cmake --build . --config ${{ matrix.build_type }} -v -j 2
+        cmake --install . --config ${{ matrix.build_type }}
 
-    - name: Install QP solver dependencies [Conda / proxQP]
+    - name: Install QP solver dependencies [proxQP]
       if: contains(matrix.qp_solver, 'proxQP')
       shell: bash -l {0}
       run: |
         conda install proxsuite
         echo "CMAKE_OPTS_QPSOLVER=-DSOFTROBOTSINVERSE_ENABLE_PROXQP=ON -DSOFTROBOTSINVERSE_ENABLE_QPOASES=OFF" >> "$GITHUB_ENV"
 
-    - name: Install QP solver dependencies [Conda / qpOases & not osx-arm64]
-      if: contains(matrix.qp_solver, 'qpOases') && !contains(matrix.os, 'macos-14')
+    - name: Install QP solver dependencies [qpOases]
+      if: contains(matrix.qp_solver, 'qpOases')
       shell: bash -l {0}
       run: |
         conda install qpoases
         echo "CMAKE_OPTS_QPSOLVER=-DSOFTROBOTSINVERSE_ENABLE_PROXQP=OFF -DSOFTROBOTSINVERSE_ENABLE_QPOASES=ON" >> "$GITHUB_ENV"        
 
-      # Use embedded qpOases version as its conda package for python>3.10 under osx-arm64 platform is not supported anymore
-    - name: Install QP solver dependencies [Conda / qpOases & osx-arm64]
-      if: contains(matrix.qp_solver, 'qpOases') && contains(matrix.os, 'macos-14')
-      shell: bash -l {0}
-      run: |
-        echo "CMAKE_OPTS_QPSOLVER=-DSOFTROBOTSINVERSE_ENABLE_PROXQP=OFF -DSOFTROBOTSINVERSE_ENABLE_QPOASES=ON" >> "$GITHUB_ENV"        
-
-    - name: Print environment [Conda]
+    - name: Print environment
       shell: bash -l {0}
       run: |
         conda info
         conda list
         env
 
-    - name: Configure [Conda / Linux & macOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+    - name: Configure SoftRobots.Inverse
       shell: bash -l {0}
       run: |
         mkdir build
@@ -100,32 +101,19 @@ jobs:
          -DPython_EXECUTABLE:PATH=${CONDA_PREFIX}/bin/python \
          -DSOFTROBOTSINVERSE_BUILD_TESTS:BOOL=ON
 
-    - name: Configure [Conda / Windows]
-      if: contains(matrix.os, 'windows')
-      shell: bash -l {0}
-      run: |
-        mkdir build
-        cd build
-        cmake .. -G"Visual Studio 17 2022" -T "v143" $CMAKE_OPTS_QPSOLVER  \
-         -DCMAKE_GENERATOR_PLATFORM=x64 \
-         -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
-         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-         -DPython_EXECUTABLE:PATH=${CONDA_PREFIX}/python.exe \
-         -DSOFTROBOTSINVERSE_BUILD_TESTS:BOOL=ON
-
-    - name: Build [Conda]
+    - name: Build SoftRobots.Inverse
       shell: bash -l {0}
       run: |
         cd build
         cmake --build . --config ${{ matrix.build_type }} -v -j 2
 
-    - name: Install [Conda]
+    - name: Install SoftRobots.Inverse
       shell: bash -l {0}
       run: |
         cd build
         cmake --install . --config ${{ matrix.build_type }}
 
-    - name: Test [Conda]
+    - name: Test SoftRobots.Inverse
       shell: bash -l {0}
       run: |
         cd build

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -33,17 +33,10 @@ jobs:
       run: |
         conda install sofa-devel sofa-python3 -c https://prefix.dev/sofa-framework-devel
 
-    - name: Install compilation environment [Linux / macOS]
-      if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
+    - name: Install compilation environment
       shell: bash -l {0}
       run: |
         conda install cmake cxx-compiler ninja pkg-config pybind11 cxxopts
-
-    - name: Install compilation environment [Windows]
-      if: contains(matrix.os, 'windows')
-      shell: bash -l {0}
-      run: |
-        conda install cmake vs2022_win-64 ninja pkg-config pybind11 cxxopts
 
     - name: Checkout SOFA SoftRobots
       uses: actions/checkout@v4

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -52,10 +52,10 @@ jobs:
         ref: master
         path: SoftRobots
 
-    - name: Configure, build & install SoftRobots
+    - name: Configure SoftRobots [Linux / macOS]
+      if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}
       run: |
-        ls -al
         cd SoftRobots
         mkdir build
         cd build
@@ -64,6 +64,24 @@ jobs:
          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
          -DPython_EXECUTABLE:PATH=${CONDA_PREFIX}/bin/python \
          -DSOFTROBOTS_BUILD_TESTS:BOOL=OFF
+
+    - name: Configure SoftRobots [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        cd SoftRobots
+        mkdir build
+        cd build
+        cmake .. -GNinja \
+         -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
+         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+         -DPython_EXECUTABLE:PATH=${CONDA_PREFIX}/python.exe \
+         -DSOFTROBOTS_BUILD_TESTS:BOOL=OFF
+
+    - name: Build & install SoftRobots
+      shell: bash -l {0}
+      run: |
+        cd SoftRobots/build
         cmake --build . --config ${{ matrix.build_type }} -v -j 2
         cmake --install . --config ${{ matrix.build_type }}
 
@@ -91,7 +109,8 @@ jobs:
         conda list
         env
 
-    - name: Configure SoftRobots.Inverse
+    - name: Configure SoftRobots.Inverse [Linux / macOS]
+      if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}
       run: |
         mkdir build
@@ -100,6 +119,18 @@ jobs:
          -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
          -DPython_EXECUTABLE:PATH=${CONDA_PREFIX}/bin/python \
+         -DSOFTROBOTSINVERSE_BUILD_TESTS:BOOL=ON
+
+    - name: Configure SoftRobots.Inverse [Windows]
+      if: contains(matrix.os, 'windows')
+      shell: bash -l {0}
+      run: |
+        mkdir build
+        cd build
+        cmake .. -GNinja $CMAKE_OPTS_QPSOLVER \
+         -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
+         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+         -DPython_EXECUTABLE:PATH=${CONDA_PREFIX}/python.exe \
          -DSOFTROBOTSINVERSE_BUILD_TESTS:BOOL=ON
 
     - name: Build SoftRobots.Inverse

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -37,13 +37,13 @@ jobs:
       if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}
       run: |
-        conda install cmake cxx-compiler ninja pkg-config pybind11
+        conda install cmake cxx-compiler ninja pkg-config pybind11 cxxopts
 
     - name: Install compilation environment [Windows]
       if: contains(matrix.os, 'windows')
       shell: bash -l {0}
       run: |
-        conda install cmake vs2022_win-64 ninja pkg-config pybind11
+        conda install cmake vs2022_win-64 ninja pkg-config pybind11 cxxopts
 
     - name: Checkout SOFA SoftRobots
       uses: actions/checkout@v4

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -1,4 +1,4 @@
-name: CI - Linux/OSX/Windows - Conda
+name: CI - Conda
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-with-conda-and-test:
-    name: "[conda:${{ matrix.os }}:py${{ matrix.python_version }}:${{ matrix.qp_solver }}]"
+    name: "${{ matrix.os }} with SOFA master from Conda devel [QPSolver = ${{ matrix.qp_solver }}]"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -47,7 +47,7 @@ jobs:
       if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}
       run: |
-        conda install cmake cxx-compilers ninja pkg-config
+        conda install cmake cxx-compiler ninja pkg-config
 
     - name: Install compilation environment [Windows]
       if: contains(matrix.os, 'windows')

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -33,16 +33,6 @@ jobs:
       run: |
         conda install sofa-devel sofa-python3 -c https://prefix.dev/sofa-framework-devel
 
-    - name: Checkout SOFA SoftRobots
-      uses: actions/checkout@v4
-      with:
-        repository: SofaDefrost/SoftRobots
-        ref: master
-        path: SoftRobots
-
-    - name: Checkout source code
-      uses: actions/checkout@v4
-
     - name: Install compilation environment [Linux / macOS]
       if: contains(matrix.os, 'ubuntu') || contains(matrix.os, 'macos')
       shell: bash -l {0}
@@ -54,6 +44,13 @@ jobs:
       shell: bash -l {0}
       run: |
         conda install cmake vs2022_win-64 ninja pkg-config
+
+    - name: Checkout SOFA SoftRobots
+      uses: actions/checkout@v4
+      with:
+        repository: SofaDefrost/SoftRobots
+        ref: master
+        path: SoftRobots
 
     - name: Configure, build & install SoftRobots
       shell: bash -l {0}
@@ -69,6 +66,9 @@ jobs:
          -DSOFTROBOTS_BUILD_TESTS:BOOL=OFF
         cmake --build . --config ${{ matrix.build_type }} -v -j 2
         cmake --install . --config ${{ matrix.build_type }}
+
+    - name: Checkout source code
+      uses: actions/checkout@v4
 
     - name: Install QP solver dependencies [proxQP]
       if: contains(matrix.qp_solver, 'proxQP')

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -58,6 +58,7 @@ jobs:
     - name: Configure, build & install SoftRobots
       shell: bash -l {0}
       run: |
+        ls -al
         cd SoftRobots
         mkdir build
         cd build


### PR DESCRIPTION
This replaces the deprecated Conda-based CI that was using the "nightly" packages, which have been removed and replaced by Conda devel packages, built for each commit on master branch of SOFA and SofaPython3.
SoftRobots has to be rebuilt from master also in this CI as it is not built as Conda devel package and we need a master version of it. It could be added to Conda devel built packages, but I believe this is not so much problematic to do it in this CI as it is light and fast to build.